### PR TITLE
Add try catch for method update_wg_usage to show propper error cause

### DIFF
--- a/common/commander.py
+++ b/common/commander.py
@@ -155,8 +155,15 @@ def apply_users():
 
 @cli.command('update-wg-usage')
 def update_wg_usage():
-    wg_raw_output = subprocess.check_output(['wg', 'show', 'hiddifywg', 'transfer'])
-    print(wg_raw_output.decode())
+    try:
+        wg_raw_output = subprocess.check_output(['wg', 'show', 'hiddifywg', 'transfer'])
+        output_str = wg_raw_output.decode()
+        if 'hiddifywg' in output_str:
+            print(output_str)
+        else:
+          raise Exception("Interface hiddifywg (wireguard) not found")
+    except subprocess.CalledProcessError as e:
+        print("Can not find interface hiddifywg, you can try change port wireguard.", e)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I faced error in refreshing usage and find out there is not interface `hiddifywg` running. 
This command raised error and not working:
`wg_raw_output = subprocess.check_output(['wg', 'show', 'hiddifywg', 'transfer'])`
after change port number wireguard in admin panel and apply changes it's worked.

