### PR TITLE
Fix docker action not running for main branch for ARM64

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -20,7 +20,7 @@ jobs:
           - linux/amd64
           - linux/arm64
         exclude:
-          - platform: ${{ github.ref != 'tag' && 'linux/arm64' }}
+          - platform: ${{ github.ref_name != 'main' && 'linux/arm64' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
In previous commit ARM64 docker publishing was broken. Based on the docs https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs we should use `github.ref_name` to filter by a branch name.