### PR TITLE
fix: correct timezone for Russia in script

### DIFF
--- a/common/install.sh
+++ b/common/install.sh
@@ -12,7 +12,7 @@ python -m pip config set global.index-url https://pypi.org/simple > /dev/null
 if [[ $COUNTRY == 'cn' ]]; then
     sudo timedatectl set-timezone Asia/Shanghai
 elif [[ $COUNTRY == 'ru' ]]; then
-    sudo timedatectl set-timezone Asia/Moscow
+    sudo timedatectl set-timezone Europe/Moscow
 else
     sudo timedatectl set-timezone Asia/Tehran
 fi


### PR DESCRIPTION
The timezone for Russia was previously set to 'Asia/Moscow', which is incorrect. Updated the script to use 'Europe/Moscow' to correctly reflect the timezone.