### PR TITLE
Update xray 25

### DIFF
--- a/common/packages.lock
+++ b/common/packages.lock
@@ -1,3 +1,6 @@
+xray|25.2.21|amd64|https://github.com/XTLS/Xray-core/releases/download/v25.2.21/Xray-linux-64.zip|3e90f0bbb5bbb2b397f46fec96b0eb4a240448bf8d282666da2f80cbaaa24fe7
+xray|25.2.21|arm64|https://github.com/XTLS/Xray-core/releases/download/v25.2.21/Xray-linux-arm64-v8a.zip|5f4d82f0d02a8646a0af0debd027503c2a8a752f04dd7f0539037ca877bb2e33
+xray|24.11.30|amd64|https://github.com/XTLS/Xray-core/releases/download/v24.11.30/Xray-linux-64.zip|679d6ec1c2ecabd84ad1e2deab6e52789c52f0a387902cc72e135a3bb3949554
 xray|24.11.30|amd64|https://github.com/XTLS/Xray-core/releases/download/v24.11.30/Xray-linux-64.zip|679d6ec1c2ecabd84ad1e2deab6e52789c52f0a387902cc72e135a3bb3949554
 xray|24.11.30|arm64|https://github.com/XTLS/Xray-core/releases/download/v24.11.30/Xray-linux-arm64-v8a.zip|9c36a345e580897dbe1eb677d39022bf5d0149814ec10308099e1ea1b630a6de
 xray|24.11.11|arm64|https://github.com/XTLS/Xray-core/releases/download/v24.11.11/Xray-linux-arm64-v8a.zip|776591f3b0b0661a45bdfad40bd2e0d18873d066f78242e05e260cf27f6b11d7

--- a/xray/configs/05_inbounds_02_realityh2_main.json.j2
+++ b/xray/configs/05_inbounds_02_realityh2_main.json.j2
@@ -19,7 +19,7 @@
 				"fallbacks": []
 				},
 				"streamSettings": {
-				"network": "h2",
+				"network": "xhttp",
 				"tcpSettings": {
 					"acceptProxyProtocol": true 
 				},

--- a/xray/configs/05_inbounds_10_trojan_httpu.json.j2
+++ b/xray/configs/05_inbounds_10_trojan_httpu.json.j2
@@ -13,9 +13,10 @@
 				]
 				},
 				"streamSettings": {
-				"network": "httpupgrade",
+				"network": "xhttp",
 				"security": "none",
-				"httpupgradeSettings": {
+				"xhttpSettings": {
+                    "mode": "stream-one",
 					"acceptProxyProtocol": true, 
 					"path":"/{{ hconfigs['path_trojan'] }}{{ hconfigs['path_httpupgrade'] }}", 
 				}

--- a/xray/configs/05_inbounds_10_vless_httpu.json.j2
+++ b/xray/configs/05_inbounds_10_vless_httpu.json.j2
@@ -14,9 +14,9 @@
 				"decryption": "none"
 				},
 				"streamSettings": {
-				"network": "httpupgrade",
+				"network": "xhttp",
 				"security": "none",
-				"httpupgradeSettings": {
+				"xhttpSettings": {
 					"acceptProxyProtocol": true,
 					"path": "/{{ hconfigs['path_vless'] }}{{ hconfigs['path_httpupgrade'] }}", 
 				}

--- a/xray/configs/05_inbounds_10_vmess_httpu.json.j2
+++ b/xray/configs/05_inbounds_10_vmess_httpu.json.j2
@@ -13,9 +13,10 @@
 				]
 				},
 				"streamSettings": {
-				"network": "httpupgrade",
+				"network": "xhttp",
 				"security": "none",
-				"httpupgradeSettings": {
+				"xhttpSettings": {
+                    "mode": "stream-one",
 					"acceptProxyProtocol": true,
 					"path": "/{{ hconfigs['path_vmess'] }}{{ hconfigs['path_httpupgrade'] }}", 
 				}

--- a/xray/configs/05_inbounds_h2_trojan_new.json.j2
+++ b/xray/configs/05_inbounds_h2_trojan_new.json.j2
@@ -14,12 +14,13 @@
 				]
 				},
 				"streamSettings": {
-				"network": "h2",
+				"network": "xhttp",
 				"security": "none",
 				"tcpSettings": {
 					"acceptProxyProtocol": true
 					},
-				"httpSettings": {
+				"xhttpSettings": {
+                        "mode": "stream-one",
 						"path": "/{{ hconfigs['path_trojan'] }}{{ hconfigs['path_tcp'] }}",
 					}
 				},

--- a/xray/configs/05_inbounds_h2_trojan_proxy.json.j2
+++ b/xray/configs/05_inbounds_h2_trojan_proxy.json.j2
@@ -14,9 +14,10 @@
 				]
 				},
 				"streamSettings": {
-				"network": "h2",
+				"network": "xhttp",
 				"security": "none",
-				"httpSettings": {
+				"xhttpSettings": {
+                        "mode": "stream-one",
 						"path": "/{{ hconfigs['path_trojan'] }}{{ hconfigs['path_tcp'] }}",
 					}
 				},

--- a/xray/configs/05_inbounds_h2_vless_new.json.j2
+++ b/xray/configs/05_inbounds_h2_vless_new.json.j2
@@ -15,9 +15,10 @@
 				"decryption": "none"
 				},
 				"streamSettings": {
-				"network": "h2",
+				"network": "xhttp",
 				"security": "none",
-				"httpSettings": {
+				"xhttpSettings": {
+                    "mode": "stream-one",
 					"path": "/{{ hconfigs['path_vless'] }}{{ hconfigs['path_tcp'] }}",
 					}
 				

--- a/xray/configs/05_inbounds_h2_vless_proxy.json.j2
+++ b/xray/configs/05_inbounds_h2_vless_proxy.json.j2
@@ -15,12 +15,13 @@
 				"decryption": "none"
 				},
 				"streamSettings": {
-				"network": "h2",
+				"network": "xhttp",
 				"security": "none",
 				"tcpSettings": {
 					"acceptProxyProtocol": true
 					},
-				"httpSettings": {
+				"xhttpSettings": {
+                    "mode": "stream-one",
 					"path": "/{{ hconfigs['path_vless'] }}{{ hconfigs['path_tcp'] }}",
 					}
 				

--- a/xray/configs/05_inbounds_h2_vmess_new.json.j2
+++ b/xray/configs/05_inbounds_h2_vmess_new.json.j2
@@ -14,9 +14,10 @@
 				]
 				},
 				"streamSettings": {
-				"network": "h2",
+				"network": "xhttp",
 				"security": "none",
-				"httpSettings": {
+				"xhttpSettings": {
+                    "mode": "stream-one",
 					"path": "/{{ hconfigs['path_vmess'] }}{{ hconfigs['path_grpc'] }}",
 				}
 				

--- a/xray/configs/05_inbounds_h2_vmess_proxy.json.j2
+++ b/xray/configs/05_inbounds_h2_vmess_proxy.json.j2
@@ -14,12 +14,13 @@
 				]
 				},
 				"streamSettings": {
-				"network": "h2",
+				"network": "xhttp",
 				"security": "none",
 				"tcpSettings": {
 					"acceptProxyProtocol": true
 					},
-				"httpSettings": {
+				"xhttpSettings": {
+                    "mode": "stream-one",
 					"path": "/{{ hconfigs['path_vmess'] }}{{ hconfigs['path_tcp'] }}",
 				}
 				


### PR DESCRIPTION
This PR updates the configuration to align with the latest changes in [Xray-core v25](https://github.com/XTLS/Xray-core/releases/tag/v24.12.18). In this release, h2 and http have been replaced with xhttp, requiring corresponding updates to our configuration files.

Additionally, we have updated package.lock to include Xray 25, ensuring compatibility with the latest version.

Changes:

Updated config files to replace h2 and http with xhttp
Added Xray 25 to package.lock
This update ensures compatibility with the latest Xray-core release while maintaining stability.