### PR TITLE
Upgrade HAProxy from 3.0 to 3.1

### DIFF
--- a/haproxy/install.sh
+++ b/haproxy/install.sh
@@ -7,9 +7,9 @@ if is_installed sniproxy; then
     pkill -9 sniproxy >/dev/null 2>&1
 fi
 
-if ! is_installed_package "haproxy=3.0"; then
-    add-apt-repository -y ppa:vbernat/haproxy-3.0
-    install_package haproxy=3.0.\*
+if ! is_installed_package "haproxy=3.1"; then
+    add-apt-repository -y ppa:vbernat/haproxy-3.1
+    install_package haproxy=3.1.\*
 fi
 systemctl kill haproxy >/dev/null 2>&1
 systemctl stop haproxy >/dev/null 2>&1


### PR DESCRIPTION
- Updated installation to target HAProxy 3.1 via vbernat/haproxy-3.1 PPA