### PR TITLE
Remove: redundant echo commit to the iptables rules EOF

### DIFF
--- a/common/utils.sh
+++ b/common/utils.sh
@@ -429,10 +429,10 @@ function save_firewall() {
     mkdir -p /etc/iptables/
     iptables-save >/etc/iptables/rules.v4
     awk -i inplace '!seen[$0]++' /etc/iptables/rules.v4
-    echo "COMMIT" >> /etc/iptables/rules.v4
+    # echo "COMMIT" >> /etc/iptables/rules.v4
     ip6tables-save >/etc/iptables/rules.v6
     awk -i inplace '!seen[$0]++' /etc/iptables/rules.v6
-    echo "COMMIT" >> /etc/iptables/rules.v6
+    # echo "COMMIT" >> /etc/iptables/rules.v6
     ip6tables-restore </etc/iptables/rules.v6
     iptables-restore </etc/iptables/rules.v4
 }


### PR DESCRIPTION
Remove the two `echo "COMMIT"` in utils.sh for the `save_firewall` function.

The Complete Bug Description can be found in Issue #4968 

`iptables-save` utility adds the `COMMIT` for the rules files. 