### PR TITLE
fix bash syntax error

### DIFF
--- a/common/hiddify_installer.sh
+++ b/common/hiddify_installer.sh
@@ -309,6 +309,8 @@ function update_from_github() {
     rm -f /opt/hiddify-manager/xray/configs/05_inbounds_02_realitygrpc*.json*
     rm -f /opt/hiddify-manager/xray/configs/05_inbounds_02_realityh2*.json*
     rm -f /opt/hiddify-manager/singbox/configs/05_inbounds_2071_realitygrpc_main.json*
+    # enable bash extented globbing to avoid bash syntax error
+    shopt -s extglob
     rm -f /opt/hiddify-manager/singbox/configs/05_inbounds_20+([123])+([1234])*.json*
 
     bash install.sh --no-gui --no-log


### PR DESCRIPTION
enable extended globbing to fix bash syntax error on line 312 of `hiddify_installer.sh`