### PR TITLE
feat: add ansible playbook for installation

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,21 @@
+- hosts: all
+  become: true
+  tasks:
+    - name: Install dependencies
+      apt:
+        name:
+          - apt-transport-https
+          - ca-certificates
+          - curl
+          - wget
+          - gnupg-agent
+          - software-properties-common
+          - git
+          - jq
+        state: present
+        update_cache: yes
+
+    - name: Run Hiddify installation script
+      shell: "cd /opt && export CREATE_EASYSETUP_LINK='true' && curl -L https://i.hiddify.com/release | bash -s -- --no-gui"
+      args:
+        creates: /opt/hiddify-manager/install.sh # This makes the task idempotent


### PR DESCRIPTION
Adds a playbook.yml file to the root of the repository. This playbook automates the installation of the Hiddify panel.

The playbook performs the following actions:
1.  Updates the apt cache and installs necessary package dependencies.
2.  Downloads and executes the official Hiddify installation script.

The installation task is made idempotent by checking for the existence of the installation script in /opt/hiddify-manager, preventing re-runs on already configured systems.

This fulfills the requirement for server environments that use an Ansible playbook for deployment.