### PR TITLE
Fix: Redis Installation Script Order for Ubuntu 24.04

### DIFF
--- a/other/redis/install.sh
+++ b/other/redis/install.sh
@@ -3,22 +3,29 @@ if ! is_installed redis-server; then
     add-apt-repository -y universe
     install_package redis-server
 fi
-ln -sf $(pwd)/hiddify-redis.service /etc/systemd/system/hiddify-redis.service >/dev/null 2>&1
-systemctl enable hiddify-redis
-touch /opt/hiddify-manager/log/system/redis-server.log
-chown redis:redis /opt/hiddify-manager/log/system/redis-server.log
+
+# STOP any running system redis first to avoid a window without a password
+systemctl disable --now redis-server >/dev/null 2>&1 || true
+pkill -9 redis-server >/dev/null 2>&1 || true
+
 chown -R redis:redis .
 chmod 600 redis.conf
 
+# Ensure a password exists in repo config before starting any service
 if ! grep -q "^requirepass" "redis.conf"; then
     # Generate a random password
     random_password=$(< /dev/urandom tr -dc 'a-zA-Z0-9' | head -c49; echo)
     # Add requirepass with the generated password to redis.conf
-    echo "requirepass $random_password" >>redis.conf   
-    systemctl disable --now redis-server >/dev/null 2>&1
-    pkill -9 redis-server
-    systemctl restart hiddify-redis
+    echo "requirepass $random_password" >>redis.conf
 fi
+
+# Wire up and start the managed service using the repo config
+ln -sf $(pwd)/hiddify-redis.service /etc/systemd/system/hiddify-redis.service >/dev/null 2>&1
+systemctl enable --now hiddify-redis
+
+# Ensure logging path exists/owned
+touch /opt/hiddify-manager/log/system/redis-server.log
+chown redis:redis /opt/hiddify-manager/log/system/redis-server.log
 
 
 


### PR DESCRIPTION
# Overview
Starting with Ubuntu 24.04, the default Redis version available through apt has been upgraded from 6.0 to 7.0. This update introduces stricter authentication policies that can cause installation failures for existing projects.
# Problem Description
## The Error
The installation process exposes a critical authentication error:

```
redis.exceptions.AuthenticationError: AUTH <password> called without any password configured for the default user. Are you sure your configuration is correct?
```
## Where It Occurs
This error manifests in `run.sh` when the script attempts to configure Redis connection parameters:
```
sed -i '/^REDIS_URI/d' app.cfg
if [ -z "${REDIS_URI_MAIN}" ]; then
    if [ -z "${REDIS_PASS}" ];then
        REDIS_PASS=$(grep '^requirepass' "../other/redis/redis.conf" | awk '{print $2}')
    fi
    REDIS_URI_MAIN="redis://:${REDIS_PASS}@127.0.0.1:6379/0"
    REDIS_URI_SSH="redis://:${REDIS_PASS}@127.0.0.1:6379/1"
fi
```

Key Difference Between Redis 6 and 7

Version | Behavior
-- | --
Redis 6 | Empty passwords are allowed and can be passed in connection strings
Redis 7 | Empty passwords are no longer valid - authentication is strictly enforced


# Root Cause Analysis
## What's Already in Place
The `redis/install.sh` script contains code designed to generate a random password if no `requirepass` given in redis.conf:

```
if ! grep -q "^requirepass" "redis.conf"; then
    # Generate a random password
    random_password=$(< /dev/urandom tr -dc 'a-zA-Z0-9' | head -c49; echo)
    # Add requirepass with the generated password to redis.conf
    echo "requirepass $random_password" >>redis.conf
fi
```
## The Problem
Despite having password generation logic in place, the installation process contains a critical flaw:

1. Redis service is enabled before configuration updates
2. Redis is started with default settings
3. Configuration update never gets applied because the service is already running
4. Password generation code remains dormant
5. 
This timing issue means the randomly generated password in `redis.conf` never been activated, leaving the service without proper authentication configuration.

# Solution
To resolve this compatibility issue, the installation workflow has been restructured:

1. Disable Redis service - Stop Redis from running during configuration
2. Stop Redis process - Ensure no Redis instances are active
3. Update Redis configuration - Apply the new redis.conf with the randomly generated password
4. Enable and start Redis - Restart Redis with the updated configuration
This ensures that the installation process works correctly on Ubuntu 24.04 and later versions that use Redis 7.0+.

# Remark
I tried to install it from my Ubuntu 24.04 and it work with following commands
```
# Assume in root user
rsync -a --delete /root/Hiddify-Manager/ /opt/hiddify-manager/
cd /opt/hiddify-manager
bash other/redis/install.sh
bash common/hiddify_installer.sh release --no-gui
```

However, if TUI is being used a -1 error will be occured. Also, it is a bit messy to use Docker to install Hiddify as there is no clear instruction and HISTORY to follow with. 




