### PR TITLE
Fix wgcf download duplication and update hash and Update package.lock

### DIFF
--- a/common/packages.lock
+++ b/common/packages.lock
@@ -25,5 +25,5 @@ ssh-liberty-bridge|1.3.0|arm64|https://github.com/hiddify/ssh-liberty-bridge/rel
 ssh-liberty-bridge|1.3.0|amd64|https://github.com/hiddify/ssh-liberty-bridge/releases/download/v1.3.0/ssh-liberty-bridge-amd64|2361ac482b5dccedab9e3910af204980353856b6a2b4da586cb67b8336bd0c9c
 xray|25.6.8|arm64|https://github.com/XTLS/Xray-core/releases/download/v25.6.8/Xray-linux-arm64-v8a.zip|ca404752f27176cdaaddf929ec65a96cf18cceba403d6d97a66cdac48ef84dfe
 xray|25.6.8|amd64|https://github.com/XTLS/Xray-core/releases/download/v25.6.8/Xray-linux-64.zip|51bcd3304fdbd64b58048b056da005fbaa6c83577fc351cae34024760e111e4b
-wgcf|2.2.28|arm64|https://github.com/ViRb3/wgcf/releases/download/v2.2.28/wgcf_2.2.28_linux_arm64|14daf9995dd447cfd037b2fe21062993446b82b94550072ea4874aecd20ed71d
-wgcf|2.2.28|amd64|https://github.com/ViRb3/wgcf/releases/download/v2.2.28/wgcf_2.2.28_linux_amd64|2cd58bfa56e6703dbea16e607705b67a558be5b32be0378f6479d71f271d0861
+wgcf|2.2.30|arm64|https://github.com/ViRb3/wgcf/releases/download/v2.2.30/wgcf_2.2.30_linux_arm64|761f1d35157feb7c527cd8b13fbe428b47a9786af207a73e380630609c3d1f40
+wgcf|2.2.30|amd64|https://github.com/ViRb3/wgcf/releases/download/v2.2.30/wgcf_2.2.30_linux_amd64|fc443008fe29a6f0b05b45d27436b7ce89e87a6836718597ccb39e41da418304

--- a/common/packages.lock
+++ b/common/packages.lock
@@ -19,11 +19,10 @@ mtproxygo|2.1.7|arm64|https://github.com/9seconds/mtg/releases/download/v2.1.7/m
 mtproxygo|2.1.7|amd64|https://github.com/9seconds/mtg/releases/download/v2.1.7/mtg-2.1.7-linux-amd64.tar.gz|af6e0cba65abe8e4e63f6e534cd6f23cc235ff987155a8a7e43e0f5b481a96e2
 v2ray-plugin|1.3.2|arm64|https://github.com/shadowsocks/v2ray-plugin/releases/download/v1.3.2/v2ray-plugin-linux-arm64-v1.3.2.tar.gz|ef07467cdbd249cdec517809d281ada91c5b4640e7f003a324d145ce1e66fec3
 v2ray-plugin|1.3.2|amd64|https://github.com/shadowsocks/v2ray-plugin/releases/download/v1.3.2/v2ray-plugin-linux-amd64-v1.3.2.tar.gz|b578514235b98b230f881aa2a01a7277205f85135bc09fc3832e5f3993ee541a
-wgcf|2.2.23|amd64|https://github.com/ViRb3/wgcf/releases/download/v2.2.23/wgcf_2.2.23_linux_amd64|2d4f9402c85982f5e6fdc64945b41491c651bbaca4e0aaf20bc31b63d3adab42
-wgcf|2.2.23|arm64|https://github.com/ViRb3/wgcf/releases/download/v2.2.23/wgcf_2.2.23_linux_arm64|3921a7af8e87be66692cf228851d0bb1290f3b1d2f2b3cebaa191dff8f0fb4c3
+wgcf|2.2.30|arm64|https://github.com/ViRb3/wgcf/releases/download/v2.2.30/wgcf_2.2.30_linux_arm64|761f1d35157feb7c527cd8b13fbe428b47a9786af207a73e380630609c3d1f40
+wgcf|2.2.30|amd64|https://github.com/ViRb3/wgcf/releases/download/v2.2.30/wgcf_2.2.30_linux_amd64|fc443008fe29a6f0b05b45d27436b7ce89e87a6836718597ccb39e41da418304
 ssh-liberty-bridge|1.3.0|arm64|https://github.com/hiddify/ssh-liberty-bridge/releases/download/v1.3.0/ssh-liberty-bridge-arm64|78cbbbf05a4d442ea79359649df76caa9c7e8d19b8889ea2d077eb2c72122a0f
 ssh-liberty-bridge|1.3.0|amd64|https://github.com/hiddify/ssh-liberty-bridge/releases/download/v1.3.0/ssh-liberty-bridge-amd64|2361ac482b5dccedab9e3910af204980353856b6a2b4da586cb67b8336bd0c9c
 xray|25.6.8|arm64|https://github.com/XTLS/Xray-core/releases/download/v25.6.8/Xray-linux-arm64-v8a.zip|ca404752f27176cdaaddf929ec65a96cf18cceba403d6d97a66cdac48ef84dfe
 xray|25.6.8|amd64|https://github.com/XTLS/Xray-core/releases/download/v25.6.8/Xray-linux-64.zip|51bcd3304fdbd64b58048b056da005fbaa6c83577fc351cae34024760e111e4b
-wgcf|2.2.30|arm64|https://github.com/ViRb3/wgcf/releases/download/v2.2.30/wgcf_2.2.30_linux_arm64|761f1d35157feb7c527cd8b13fbe428b47a9786af207a73e380630609c3d1f40
-wgcf|2.2.30|amd64|https://github.com/ViRb3/wgcf/releases/download/v2.2.30/wgcf_2.2.30_linux_amd64|fc443008fe29a6f0b05b45d27436b7ce89e87a6836718597ccb39e41da418304
+


### PR DESCRIPTION
The wgcf binary was being downloaded twice.

Changes:
- Removed the old wgcf download logic.
- Added the updated wgcf binary.
- Updated the hash to match the new wgcf version.

This removes duplication and ensures the correct binary and checksum are used.
