### PR TITLE
Fix double certificate issuance logic in get_cert

### DIFF
--- a/acme.sh/cert_utils.sh
+++ b/acme.sh/cert_utils.sh
@@ -65,14 +65,14 @@ function get_cert() {
             acmecmd -d $DOMAIN --server letsencrypt --certificate-profile shortlived --days 6 
         elif isipv6 "$DOMAIN"; then
             acmecmd -d [$DOMAIN] --server letsencrypt --certificate-profile shortlived --days 6 
-        else 
-            acmecmd -d $DOMAIN --server letsencrypt
-            if is_ok_domain_zerossl "$DOMAIN"; then
-                acmecmd -d $DOMAIN 
-            fi
-        fi
-        
+        else
+            acmecmd -d "$DOMAIN" --server letsencrypt
+            err=$?
 
+            if [ "$err" -ne 0 ] && is_ok_domain_zerossl "$DOMAIN"; then
+          acmecmd -d "$DOMAIN" --server zerossl
+        fi
+    fi
         cp $ssl_cert_path/$DOMAIN.crt $ssl_cert_path/$DOMAIN.crt.bk
         cp $ssl_cert_path/$DOMAIN.crt.key $ssl_cert_path/$DOMAIN.crt.key.bk
         acme.sh --installcert -d $DOMAIN \


### PR DESCRIPTION
Previously, the script always attempted a second certificate issuance without checking the result of the first one, which could override a successful Let's Encrypt certificate with a fallback CA.

Now, ZeroSSL is only used as a fallback if Let's Encrypt fails and the domain is allowed. This makes the behavior deterministic and prevents unnecessary duplicate issuance attempts.