### PR TITLE
prevent installcert when acme issue fails

### DIFF
--- a/acme.sh/cert_utils.sh
+++ b/acme.sh/cert_utils.sh
@@ -70,8 +70,15 @@ function get_cert() {
             err=$?
 
             if [ "$err" -ne 0 ] && is_ok_domain_zerossl "$DOMAIN"; then
-          acmecmd -d "$DOMAIN" --server zerossl
-        fi
+            acmecmd -d "$DOMAIN" --server zerossl
+            err=$?
+            fi
+
+            if [ "$err" -ne 0 ]; then
+            echo "acme issue failed, skipping installcert"
+            bash generate_self_signed_cert.sh $DOMAIN
+            return 1
+            fi
     fi
         cp $ssl_cert_path/$DOMAIN.crt $ssl_cert_path/$DOMAIN.crt.bk
         cp $ssl_cert_path/$DOMAIN.crt.key $ssl_cert_path/$DOMAIN.crt.key.bk


### PR DESCRIPTION
Previously, if acmecmd --issue failed (e.g. challenge verification error), the script still proceeded to run acme.sh --installcert.

This caused errors like missing fullchain.cer, because the certificate was never successfully issued.

This patch adds a simple check for the final err value after issuing the certificate (including ZeroSSL fallback). If issuing fails, the script skips installcert and falls back to generating a self-signed certificate.

No functional changes to the success path. Only prevents invalid install attempts after failure.