### PR TITLE
fix: no Dockerfile when install stable version with docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,10 @@
 services:
   hiddify:
     #only for local build and development
-    build: .
+    #build: .
 
     #latest release version
-    #image: ghcr.io/hiddify/hiddify-manager:latest
+    image: ghcr.io/hiddify/hiddify-manager:latest
 
     #latest beta version
     #image: ghcr.io/hiddify/hiddify-manager:beta


### PR DESCRIPTION
[Installing HiddifyManager using Docker](https://hiddify.com/manager/installation-and-setup/Install-Hiddify-using-Docker/)

```bash
bash <(curl https://i.hiddify.com/docker/latest)
```