### PR TITLE
fix: redis parameter delayed parsing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     volumes:
        - ./docker-data/:/hiddify-data/
     env_file:
-      - path: ./docker.env
+      - path: docker.env
     #environment:
       #REDIS_PASSWORD used if REDIS_URI_MAIN or REDIS_URI_SSH is not set
       #MYSQL_PASSWORD used if SQLALCHEMY_DATABASE_URI is not set
@@ -41,7 +41,7 @@ services:
     container_name: mariadb_container
     restart: always
     env_file:
-      - path: ./docker.env
+      - path: docker.env
     environment:
       MARIADB_RANDOM_ROOT_PASSWORD: 1       # Root user password
       MYSQL_DATABASE: hiddifypanel             
@@ -54,8 +54,8 @@ services:
     container_name: redis_container
     restart: always
     env_file:
-      - path: ./docker.env
-    command: sh -c "redis-server --requirepass \"$REDIS_PASSWORD\""
+      - path: docker.env
+    command: sh -c "redis-server --requirepass \"$${REDIS_PASSWORD}\""
     volumes:
       - ./docker-data/redis_data:/data                # Persistent storage for Redis data
     


### PR DESCRIPTION
https://github.com/hiddify/Hiddify-Manager/issues/5134

In the command of docker-compose.yml, the single $ environment variable will be parsed on the host and executed directly in the container, and env_file does not participate in the parsing process, which causes the redis password to be actually empty. There are two solutions, one of which is to rename docker.env to .env. Another solution is to add an additional $ to the environment variables that need to be parsed within the container, which will cause the corresponding variables to be parsed within the container. Both solutions can meet the requirement that redis needs to obtain the password from the environment variable passed in the parameter.

fix: #5134