### PR TITLE
fix: bypass cli_progress wrapper when stdout is not a TTY

### DIFF
--- a/common/utils.sh
+++ b/common/utils.sh
@@ -442,6 +442,33 @@ function save_firewall() {
 function show_progress_window() {
     disable_ansii_modes
     activate_python_venv
+    # Non-interactive runs (SSH without PTY, cron, background apply) hang forever in
+    # cli_progress urwid when wrapped this way. Run the target command directly.
+    # See https://github.com/hiddify/Hiddify-Manager/issues/5479
+    if [[ ! -t 1 ]]; then
+        local -a run_cmd=()
+        local skip=0
+        for arg in "$@"; do
+            if [[ $skip -eq 1 ]]; then
+                skip=0
+                continue
+            fi
+            case "$arg" in
+                --log|--title|--subtitle|--regex)
+                    skip=1
+                    ;;
+                --)
+                    ;;
+                *)
+                    run_cmd+=("$arg")
+                    ;;
+            esac
+        done
+        bash "${run_cmd[@]}"
+        exit_code=$?
+        disable_ansii_modes
+        return $exit_code
+    fi
     install_pypi_package cli-progress
     python -m cli_progress --title "Hiddify Manager" "$@"
     exit_code=$?


### PR DESCRIPTION
## Summary

`apply_configs` / `apply_users` hang indefinitely when invoked without a TTY because `show_progress_window()` always wraps the command in `python -m cli_progress` (urwid UI). The subprocess may finish and regenerate configs, but the wrapper never exits and can block later applies (exit 12 lock).

**Impact:** After Admin API user renew, panel DB is correct but sing-box protocols (Hy2/TUIC/Mieru/Naive) stay stale until manual SSH intervention.

## Fix

In `show_progress_window()`, detect non-TTY stdout (`[ ! -t 1 ]`) and run the wrapped install/apply command directly, skipping `cli_progress`.

Interactive installs still use the progress UI.

## Reproduction

```bash
ssh -T root@server 'bash /opt/hiddify-manager/apply_configs.sh'
pgrep -af cli_progress   # stuck 15+ minutes, 0-byte install log
systemctl show hiddify-singbox -p ActiveEnterTimestamp  # unchanged
```

Manual workaround that worked: kill `cli_progress`, run `commander.py apply-users`, restart sing-box.

## Related

Fixes #5479
Related: #5505, #5498, #4926

Companion PR: hiddify/cli_progress#TBD

Verified on production 12.3.3 across Montreal / Helsinki / Nuremberg.

Made with [Cursor](https://cursor.com)