### PR TITLE
Fix speedtest routing through HAProxy

### DIFF
--- a/haproxy/fronts/in_tcpmode.cfg.pj2
+++ b/haproxy/fronts/in_tcpmode.cfg.pj2
@@ -20,6 +20,9 @@ frontend in-tcpmode
 
     use_backend generate_204 if { path -i /{{hconfigs['proxy_path_client']}}/generate_204 }
     use_backend generate_204 if { path -i /{{hconfigs['proxy_path']}}/generate_204 }
+    {% if hconfigs['speed_test'] %}
+    use_backend nginx_dispatcher_http_h2 if { path_beg /{{hconfigs['proxy_path_client']}}/speedtest/ }
+    {% endif %}
     use_backend hiddifypanel if { path_beg /{{hconfigs['proxy_path_client']}}/  }
     use_backend hiddifypanel if { path_beg /{{hconfigs['proxy_path_admin']}}/ hiddifypanel }
     use_backend hiddifypanel if { path_beg /{{hconfigs['proxy_path']}}/ hiddifypanel }
@@ -74,4 +77,3 @@ frontend in-tcpmode
 
     
     default_backend to_httpmode
-

--- a/haproxy/maps/path.j2
+++ b/haproxy/maps/path.j2
@@ -1,3 +1,6 @@
+{% if hconfigs['speed_test'] %}
+/{{hconfigs['proxy_path_client']}}/speedtest/ nginx_dispatcher_http_h2
+{% endif %}
 /{{hconfigs['proxy_path_client']}}/ hiddifypanel
 /{{hconfigs['proxy_path_admin']}}/ hiddifypanel
 /{{hconfigs['proxy_path']}}/ hiddifypanel
@@ -30,6 +33,5 @@
 #/{{ hconfigs['path_ss'] }}{{ hconfigs['path_xhttp'] }} v2rayhs
 /{{ hconfigs['path_trojan'] }}{{ hconfigs['path_xhttp'] }} trojanhs
 {%endif%}
-
 
 

--- a/haproxy/maps/path_h2.j2
+++ b/haproxy/maps/path_h2.j2
@@ -1,4 +1,7 @@
 /{{hconfigs['proxy_path_client']}}/static/ nginx_dispatcher_http_h2
+{% if hconfigs['speed_test'] %}
+/{{hconfigs['proxy_path_client']}}/speedtest/ nginx_dispatcher_http_h2
+{% endif %}
 /{{hconfigs['proxy_path_client']}}/ hiddifypanel
 /{{hconfigs['proxy_path_admin']}}/ hiddifypanel
 /{{hconfigs['proxy_path']}}/ hiddifypanel

--- a/haproxy/maps/path_v10.j2
+++ b/haproxy/maps/path_v10.j2
@@ -18,6 +18,9 @@
 /{{ hconfigs['proxy_path_admin'] }}/proxy-stats/ proxy_stats_ui_backend
 
 /{{hconfigs['proxy_path_client']}}/static/ nginx_dispatcher_http_h2
+{% if hconfigs['speed_test'] %}
+/{{hconfigs['proxy_path_client']}}/speedtest/ nginx_dispatcher_http_h2
+{% endif %}
 /{{hconfigs['proxy_path_client']}}/ hiddifypanel
 /{{hconfigs['proxy_path_admin']}}/ hiddifypanel
 /{{hconfigs['proxy_path']}}/ hiddifypanel


### PR DESCRIPTION
## What changed

- route the client speedtest path to `nginx_dispatcher_http_h2` before the generic panel path
- apply the route consistently to HTTP map variants and TCP-mode dispatch
- generate the route only when `speed_test` is enabled

## Why

The bundled OpenSpeedTest service can be healthy on `127.0.0.1:438`, while the public URL returns `{"message":"Not Found"}`. HAProxy currently matches the broader client panel prefix first, so the request reaches Hiddify Panel instead of the Nginx speedtest location.

This fixes #5040 and #5435.

## Validation

Rendered all changed Jinja templates with `speed_test` enabled and disabled. Verified that the specific speedtest route is present and precedes the generic panel route only when enabled.