### PR TITLE
feat(telegram): add telEgo backend

### DIFF
--- a/scripts/common/packages.lock
+++ b/scripts/common/packages.lock
@@ -45,6 +45,8 @@ vaydns|0.2.0|arm64|https://github.com/net2share/vaydns/releases/download/v0.2.0/
 vaydns|0.2.0|amd64|https://github.com/net2share/vaydns/releases/download/v0.2.0/vaydns-server-linux-amd64|2e50a8ea286dcf4299d5aa485a501d079d3ee2dd7b6388315d6eb4131ac9e2c8
 telemt|3.3.31|arm64|https://github.com/telemt/telemt/releases/download/3.3.31/telemt-aarch64-linux-gnu.tar.gz|a52c6577b69c536a716eb86a389a5baff8eb98e616074aad118d82bc3ea98029
 telemt|3.3.31|amd64|https://github.com/telemt/telemt/releases/download/3.3.31/telemt-x86_64-linux-gnu.tar.gz|2e3acac4db63b61653c9026ff42af8733cb37c95dce738331c414dcc78226bcd
+telego|0.5.4|arm64|https://github.com/Scratch-net/telego/releases/download/v0.5.4/telego_0.5.4_linux_arm64.tar.gz|827bccdbba3f414ff365e2c31d276a991c857bebd7f107741270d622e5ac20d6
+telego|0.5.4|amd64|https://github.com/Scratch-net/telego/releases/download/v0.5.4/telego_0.5.4_linux_amd64.tar.gz|e0dc07bb6e9b5a701e4feb3821bce3579e62639663459c3d69d275988ddb9a79
 vaydns|0.2.4|arm64|https://github.com/net2share/vaydns/releases/download/v0.2.4/vaydns-server-linux-arm64|97218d73f3256877770eae80acd746b982fc2a65c511fb59de7a7e48298c5168
 vaydns|0.2.4|amd64|https://github.com/net2share/vaydns/releases/download/v0.2.4/vaydns-server-linux-amd64|8fb10c1ead71d46dbc23e92b15675c993a10d5678948e2fc133599782e69a6d6
 vaydns|0.2.5|arm64|https://github.com/net2share/vaydns/releases/download/v0.2.5/vaydns-server-linux-arm64|f74e9b27bb87b2d777288a4eb0ac5b2676a0052c7109d7ed0b861ab895159a32

--- a/services/telegram/telego/add_version.sh
+++ b/services/telegram/telego/add_version.sh
@@ -1,0 +1,4 @@
+latest=$1
+source /opt/hiddify-manager/scripts/common/package_manager.sh
+add_package telego "$latest" arm64 "https://github.com/Scratch-net/telego/releases/download/v$latest/telego_${latest}_linux_arm64.tar.gz"
+add_package telego "$latest" amd64 "https://github.com/Scratch-net/telego/releases/download/v$latest/telego_${latest}_linux_amd64.tar.gz"

--- a/services/telegram/telego/config.toml.j2
+++ b/services/telegram/telego/config.toml.j2
@@ -1,0 +1,22 @@
+[general]
+bind-to = "127.0.0.1:1001"
+log-level = "info"
+proxy-protocol = true
+
+[secrets]
+default = "{{ hconfigs['shared_secret'].replace("-", "") }}"
+{% for u in users %}
+{{ u['uuid'].replace("-", "") }} = "{{ u['uuid'].replace("-", "") }}"
+{% endfor %}
+
+[tls-fronting]
+mask-host = "{{ hconfigs['telegram_fakedomain'] }}"
+
+[performance]
+prefer-ip = "prefer-ipv4"
+idle-timeout = "5m"
+num-event-loops = 0
+
+[metrics]
+bind-to = "127.0.0.1:10087"
+path = "/metrics"

--- a/services/telegram/telego/install.sh
+++ b/services/telegram/telego/install.sh
@@ -1,0 +1,13 @@
+source /opt/hiddify-manager/scripts/common/package_manager.sh
+
+if download_package telego telego.tar.gz; then
+    :
+elif ! is_installed ./telego; then
+    download_package telego telego.tar.gz force || exit 1
+else
+    exit 0
+fi
+
+tar -xzf telego.tar.gz telego || exit 1
+rm -f telego.tar.gz
+set_installed_version telego

--- a/services/telegram/telego/mtproxy.service
+++ b/services/telegram/telego/mtproxy.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=telEgo - Telegram MTProxy server
+Documentation=https://github.com/Scratch-net/telego
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/hiddify-manager/services/telegram/telego/
+ExecStart=/opt/hiddify-manager/services/telegram/telego/telego run -c ./config.toml
+Restart=on-failure
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/services/telegram/telego/run.sh
+++ b/services/telegram/telego/run.sh
@@ -1,0 +1,6 @@
+ln -sf "$(pwd)/mtproxy.service" /etc/systemd/system/mtproxy.service
+systemctl enable mtproxy.service
+chmod 600 config.toml
+systemctl restart mtproxy.service
+
+systemctl status mtproxy --no-pager


### PR DESCRIPTION
Add telEgo v0.5.4 as a Hiddify Telegram proxy backend.

The service:

- installs verified AMD64 and ARM64 release archives;
- listens on Hiddify's existing private port `127.0.0.1:1001`;
- accepts PROXY protocol from the public layer-4 frontend;
- configures the shared secret and one UUID secret per user;
- exposes per-user Prometheus traffic counters on `127.0.0.1:10087`.

Depends on hiddify/hiddifypanel#36, which adds the panel selector, per-user links, and usage accounting. After that PR merges, this branch must update the Panel submodule before this PR is ready to merge.

The initial integration enables MTProxy only. Hiddify's current Telegram fake-domain setting is an external FakeTLS mask, not an owned WEB hostname with a certificate. Native WEB carrier support therefore needs a separate frontend and panel settings change.

Validation completed:

- verified both release archive SHA-256 hashes;
- extracted and ran the v0.5.4 AMD64 binary;
- rendered the Jinja template and parsed the resulting TOML;
- started telEgo with the rendered settings and reached its metrics endpoint;
- checked all shell scripts with `bash -n`.
